### PR TITLE
Diagonalize before multiplying by time-step in the case of Hermitian operators

### DIFF
--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -56,13 +56,13 @@ function expv!(w::AbstractVector{T}, t::Number, Ks::KrylovSubspace{B, T, U};
     else
         throw(ArgumentError("Cache must be an ExpvCache"))
     end
-    lmul!(t, copyto!(cache, @view(H[1:m, :])))
+    copyto!(cache, @view(H[1:m, :]))
     if ishermitian(cache)
         # Optimize the case for symtridiagonal H
         F = eigen!(SymTridiagonal(cache))
-        expHe = F.vectors * (exp.(F.values) .* @view(F.vectors[1, :]))
+        expHe = F.vectors * (exp.(t*F.values) .* @view(F.vectors[1, :]))
     else
-        expH = exp!(cache)
+        expH = exp!(t*cache)
         expHe = @view(expH[:, 1])
     end
     lmul!(beta, mul!(w, @view(V[:, 1:m]), expHe)) # exp(A) ≈ norm(b) * V * exp(H)e

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -60,9 +60,9 @@ function expv!(w::AbstractVector{T}, t::Number, Ks::KrylovSubspace{B, T, U};
     if ishermitian(cache)
         # Optimize the case for symtridiagonal H
         F = eigen!(SymTridiagonal(cache))
-        expHe = F.vectors * (exp.(t*F.values) .* @view(F.vectors[1, :]))
+        expHe = F.vectors * (exp.(lmul!(t,F.values)) .* @view(F.vectors[1, :]))
     else
-        expH = exp!(t*cache)
+        expH = exp!(lmul!(t,cache))
         expHe = @view(expH[:, 1])
     end
     lmul!(beta, mul!(w, @view(V[:, 1:m]), expHe)) # exp(A) ≈ norm(b) * V * exp(H)e


### PR DESCRIPTION
This enables the use of Lanczos iteration for e.g. skew-Hermitian matrices by multiplying the operator by `im` when performing the Krylov iteration (thus yielding a Hermitian operator) and then taking a complex time-step.