### PR TITLE
Alternative interface to expv!

### DIFF
--- a/src/ExponentialUtilities.jl
+++ b/src/ExponentialUtilities.jl
@@ -6,6 +6,7 @@ include("phi.jl")
 include("arnoldi.jl")
 include("krylov_phiv.jl")
 include("krylov_phiv_adaptive.jl")
+include("krylov_expv.jl")
 
 export phi, phi!, KrylovSubspace, arnoldi, arnoldi!, lanczos!, ExpvCache, PhivCache,
     expv, expv!, phiv, phiv!, expv_timestep, expv_timestep!, phiv_timestep, phiv_timestep!

--- a/src/ExponentialUtilities.jl
+++ b/src/ExponentialUtilities.jl
@@ -9,5 +9,6 @@ include("krylov_phiv_adaptive.jl")
 include("krylov_expv.jl")
 
 export phi, phi!, KrylovSubspace, arnoldi, arnoldi!, lanczos!, ExpvCache, PhivCache,
-    expv, expv!, phiv, phiv!, expv_timestep, expv_timestep!, phiv_timestep, phiv_timestep!
+    expv, expv!, phiv, phiv!, expv_timestep, expv_timestep!, phiv_timestep, phiv_timestep!,
+    StegrCache, get_subspace_cache
 end

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -61,7 +61,7 @@ coeff(::Type{U},α::T) where {U<:Real,T<:Complex} = real(α)
 #######################################
 # Arnoldi/Lanczos with custom IOP
 """
-    arnoldi(A,b[;m,tol,opnorm,iop,cache]) -> Ks
+    arnoldi(A,b[;m,tol,opnorm,iop]) -> Ks
 
 Performs `m` anoldi iterations to obtain the Krylov subspace K_m(A,b).
 
@@ -86,14 +86,13 @@ advection-diffusion operator using the incomplete orthogonalization method. In
 Numerical Mathematics and Advanced Applications-ENUMATH 2013 (pp. 345-353).
 Springer, Cham.
 """
-function arnoldi(A, b; m=min(30, size(A, 1)), tol=1e-7, opnorm=LinearAlgebra.opnorm,
-                 iop=0, cache=nothing)
+function arnoldi(A, b; m=min(30, size(A, 1)), tol=1e-7, opnorm=LinearAlgebra.opnorm, iop=0)
     Ks = KrylovSubspace{eltype(b)}(length(b), m)
-    arnoldi!(Ks, A, b; m=m, tol=tol, opnorm=opnorm, cache=cache, iop=iop)
+    arnoldi!(Ks, A, b; m=m, tol=tol, opnorm=opnorm, iop=iop)
 end
 
 """
-    arnoldi_step!(j, A, V, H, cache)
+    arnoldi_step!(j, A, V, H)
 
 Take the `j`:th step of the Lanczos iteration.
 """
@@ -112,16 +111,15 @@ function arnoldi_step!(j::Integer, iop::Integer, n::Integer, A,
     beta
 end
 """
-    arnoldi!(Ks,A,b[;tol,m,opnorm,iop,cache]) -> Ks
+    arnoldi!(Ks,A,b[;tol,m,opnorm,iop]) -> Ks
 
 Non-allocating version of `arnoldi`.
 """
 function arnoldi!(Ks::KrylovSubspace{B, T, U}, A, b::AbstractVector{T};
                   tol::Real=1e-7, m::Int=min(Ks.maxiter, size(A, 1)),
-                  opnorm=LinearAlgebra.opnorm,
-                  iop::Int=0, cache=nothing) where {B, T <: Number, U <: Number}
+                  opnorm=LinearAlgebra.opnorm, iop::Int=0) where {B, T <: Number, U <: Number}
     if ishermitian(A)
-        return lanczos!(Ks, A, b; tol=tol, m=m, opnorm=opnorm, cache=cache)
+        return lanczos!(Ks, A, b; tol=tol, m=m, opnorm=opnorm)
     end
     if m > Ks.maxiter
         resize!(Ks, m)
@@ -151,7 +149,7 @@ function arnoldi!(Ks::KrylovSubspace{B, T, U}, A, b::AbstractVector{T};
 end
 
 """
-    lanczos_step!(j, A, V, H, cache)
+    lanczos_step!(j, A, V, H)
 
 Take the `j`:th step of the Lanczos iteration.
 """
@@ -192,15 +190,14 @@ Returns a view of the real components of the real vector `V`.
 realview(::Type{R}, V::AbstractVector{R}) where {R} = V
 
 """
-    lanczos!(Ks,A,b[;tol,m,opnorm,cache]) -> Ks
+    lanczos!(Ks,A,b[;tol,m,opnorm]) -> Ks
 
 A variation of `arnoldi!` that uses the Lanczos algorithm for
 Hermitian matrices.
 """
 function lanczos!(Ks::KrylovSubspace{B, T, U}, A, b::AbstractVector{T};
                   tol=1e-7, m=min(Ks.maxiter, size(A, 1)),
-                  opnorm=LinearAlgebra.opnorm,
-                  cache=nothing) where {B, T <: Number, U <: Number}
+                  opnorm=LinearAlgebra.opnorm) where {B, T <: Number, U <: Number}
     if m > Ks.maxiter
         resize!(Ks, m)
     else

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -177,8 +177,18 @@ macro diagview(A,d::Integer=0)
     end
 end
 
+"""
+    realview(R, V)
+
+Returns a view of the real components of the complex vector `V`.
+"""
 realview(::Type{R}, V::AbstractVector{C}) where {R,C<:Complex} =
     @view(reinterpret(R, V)[1:2:end])
+"""
+    realview(R, V)
+
+Returns a view of the real components of the real vector `V`.
+"""
 realview(::Type{R}, V::AbstractVector{R}) where {R} = V
 
 """
@@ -206,6 +216,7 @@ function lanczos!(Ks::KrylovSubspace{B, T, U}, A, b::AbstractVector{T};
     Ks.beta = norm(b)
     @. V[:, 1] = b / Ks.beta
     α = @diagview(H)
+    # β is always real, even though α may (in general) be complex.
     β = realview(B, @diagview(H,-1))
     @inbounds for j = 1:m
         if vtol > lanczos_step!(j, m, n, A, V, α, β)

--- a/src/krylov_expv.jl
+++ b/src/krylov_expv.jl
@@ -5,6 +5,17 @@ abstract type HermitianSubspaceCache{T} <: SubspaceCache{T} end
 
 include("stegr_cache.jl")
 
+"""
+    expv!(w, t, A, b, Ks, cache)
+
+Alternative interface for calculating the action of `exp(t*A)` on the
+vector `b`, storing the result in `w`. The Krylov iteration is
+terminated when an error estimate for the matrix exponential in the
+generated subspace is below the requested tolerance. `Ks` is a
+`KrylovSubspace` and `typeof(cache)<:HermitianSubspaceCache`, the
+exact type decides which algorithm is used to compute the subspace
+exponential.
+"""
 function expv!(w::AbstractVector{T}, t::Number, A, b::AbstractVector{T},
                Ks::KrylovSubspace{B, T, B}, cache::HSC;
                atol::B=1.0e-8, rtol::B=1.0e-4,
@@ -13,7 +24,7 @@ function expv!(w::AbstractVector{T}, t::Number, A, b::AbstractVector{T},
     if m > Ks.maxiter
         resize!(Ks, m)
     else
-        Ks.m = m # might change if happy-breakdown occurs
+        Ks.m = m # might change if error estimate is below requested tolerance
     end
 
     V, H = getV(Ks), getH(Ks)

--- a/src/krylov_expv.jl
+++ b/src/krylov_expv.jl
@@ -5,6 +5,11 @@ abstract type HermitianSubspaceCache{T} <: SubspaceCache{T} end
 
 include("stegr_cache.jl")
 
+get_subspace_cache(Ks::KrylovSubspace{B,T,U}) where {B,T,U<:Complex} =
+    error("Subspace exponential caches not yet available for non-Hermitian matrices.")
+get_subspace_cache(Ks::KrylovSubspace{B,T,U}) where {B,T,U<:Real} =
+    StegrCache(Ks)
+
 """
     expv!(w, t, A, b, Ks, cache)
 

--- a/src/krylov_expv.jl
+++ b/src/krylov_expv.jl
@@ -1,0 +1,48 @@
+using Printf
+
+abstract type SubspaceCache{T} end
+abstract type HermitianSubspaceCache{T} <: SubspaceCache{T} end
+
+include("stegr_cache.jl")
+
+function expv!(w::AbstractVector{T}, t::Number, A, b::AbstractVector{T},
+               Ks::KrylovSubspace{B, T, B}, cache::HSC;
+               atol::B=1.0e-8, rtol::B=1.0e-4,
+               m=min(Ks.maxiter, size(A,1)),
+               verbose::Bool=false) where {B, T <: Number, HSC <: HermitianSubspaceCache}
+    if m > Ks.maxiter
+        resize!(Ks, m)
+    else
+        Ks.m = m # might change if happy-breakdown occurs
+    end
+
+    V, H = getV(Ks), getH(Ks)
+    Ks.beta = norm(b)
+    @. V[:, 1] = b / Ks.beta
+
+    ε = atol + rtol * Ks.beta
+    verbose && @printf("Initial norm: β₀ %e, stopping threshold: %e\n", Ks.beta, ε)
+
+    α = @diagview(H)
+    β = @diagview(H,-1)
+    n = size(V, 1)
+
+    for j ∈ 1:m
+        lanczos_step!(j, m, n, A, V, α, β)
+        expT!(@view(α[1:j]), @view(β[1:j]), t, cache)
+
+        # This is practical error estimate Er₂ from
+        #
+        #   Saad, Y. (1992). Analysis of some Krylov subspace
+        #   approximations. SIAM Journal on Numerical Analysis.
+        σ = β[j]*Ks.beta*abs(cache.v[j])
+        verbose && @printf("iter %d, α[%d] %e, β[%d] %e, σ %e\n",j, j, α[j], j, β[j], σ)
+        if σ < ε
+            Ks.m = j
+            break
+        end
+    end
+    verbose && println("Krylov subspace size: ", Ks.m)
+
+    lmul!(Ks.beta, mul!(w, @view(Ks.V[:,1:Ks.m]), @view(cache.v[1:Ks.m])))
+end

--- a/src/krylov_phiv_adaptive.jl
+++ b/src/krylov_phiv_adaptive.jl
@@ -166,7 +166,7 @@ function phiv_timestep!(U::AbstractMatrix{T}, ts::Vector{tType}, A, B::AbstractM
             end
         end
         # Part 2: compute ϕp(tau*A)wp using Krylov, possibly with adaptation
-        arnoldi!(Ks, A, @view(W[:, end]); tol=tol, m=m, opnorm=opnorm, iop=iop, cache=u)
+        arnoldi!(Ks, A, @view(W[:, end]); tol=tol, m=m, opnorm=opnorm, iop=iop)
         _, epsilon = phiv!(P, tau, Ks, p + 1; cache=phiv_cache, correct=correct, errest=true)
         verbose && println("t = $t, m = $m, tau = $tau, error estimate = $epsilon")
         if adaptive
@@ -180,7 +180,7 @@ function phiv_timestep!(U::AbstractMatrix{T}, ts::Vector{tType}, A, B::AbstractM
                 m, m_old = m_new, m
                 tau, tau_old = tau_new, tau
                 # Compute ϕp(tau*A)wp using the new parameters
-                arnoldi!(Ks, A, @view(W[:, end]); tol=tol, m=m, opnorm=opnorm, iop=iop, cache=u)
+                arnoldi!(Ks, A, @view(W[:, end]); tol=tol, m=m, opnorm=opnorm, iop=iop)
                 _, epsilon_new = phiv!(P, tau, Ks, p + 1; cache=phiv_cache, correct=correct, errest=true)
                 epsilon, epsilon_old = epsilon_new, epsilon
                 omega = (tend / tau) * (epsilon / abstol)

--- a/src/stegr_cache.jl
+++ b/src/stegr_cache.jl
@@ -1,0 +1,108 @@
+import LinearAlgebra.BLAS: @blasfunc
+import LinearAlgebra: BlasInt
+import LinearAlgebra.LAPACK: stegr!
+const liblapack = Base.liblapack_name
+
+mutable struct StegrWork{T<:Real}
+    jobz::Char
+    range::Char
+    dv::Vector{T}
+    ev::Vector{T}
+    vl::Real
+    vu::Real
+    il::BlasInt
+    iu::BlasInt
+    abstol::Vector{T}
+    m::Vector{BlasInt}
+    w::Vector{T}
+    Z::Matrix{T}
+    isuppz::Vector{BlasInt}
+    work::Vector{T}
+    lwork::BlasInt
+    iwork::Vector{BlasInt}
+    liwork::BlasInt
+    info::Vector{BlasInt}
+end
+
+for (stegr,elty) in ((:dstegr_,:Float64),
+                     (:sstegr_,:Float32))
+    @eval begin
+        function stegr!(n::BlasInt, sw::StegrWork{$elty})
+            ldz = stride(sw.Z, 2)
+            ccall((@blasfunc($stegr), liblapack), Cvoid,
+                  (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ptr{$elty},
+                   Ptr{$elty}, Ref{$elty}, Ref{$elty}, Ref{BlasInt},
+                   Ref{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
+                   Ptr{$elty}, Ref{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
+                   Ref{BlasInt}, Ptr{BlasInt}, Ref{BlasInt}, Ptr{BlasInt}),
+                  sw.jobz, sw.range, n,
+                  sw.dv, sw.ev,
+                  sw.vl, sw.vu, sw.il, sw.iu,
+                  sw.abstol, sw.m,
+                  sw.w, sw.Z, ldz,
+                  sw.isuppz, sw.work, sw.lwork, sw.iwork, sw.liwork,
+                  sw.info)
+        end
+    end
+end
+
+function stegr!(α::AbstractVector{T}, β::AbstractVector{T}, sw::StegrWork{T}) where T
+    # @assert length(sw.dv) >= length(α)
+    # @assert length(sw.ev) >= length(β)
+    copyto!(sw.dv, α)
+    copyto!(sw.ev, β)
+    n = BlasInt(length(α))
+    stegr!(n, sw)
+end
+
+function StegrWork(::Type{T}, n::BlasInt,
+                   jobz::Char = 'V', range::Char = 'A') where T
+    dv = Array{T}(undef, n)
+    ev = Array{T}(undef, n)
+    abstol = Array{T}(undef, 1)
+    m = Vector{BlasInt}(undef, 1)
+    w = Array{T}(undef, n)
+    ldz = jobz == 'N' ? 1 : n
+    Z = Array{T}(undef, ldz, n)
+    isuppz = Array{BlasInt}(undef, 2n)
+    work = Array{T}(undef, 1)
+    lwork = -one(BlasInt)
+    iwork = Array{BlasInt}(undef, 1)
+    liwork = -one(BlasInt)
+    info = Array{BlasInt}(undef, 1)
+    sw = StegrWork(jobz, range,
+                   dv, ev,
+                   0.0, 0.0,
+                   BlasInt(0), BlasInt(0),
+                   abstol, m,
+                   w, Z,
+                   isuppz,
+                   work, lwork,
+                   iwork, liwork,
+                   info)
+    # Call stegr! once to query for necessary workspace sizes.
+    stegr!(n, sw)
+    sw.lwork = BlasInt(sw.work[1])
+    sw.work = Array{T}(undef, sw.lwork)
+    sw.liwork = sw.iwork[1]
+    sw.iwork = Array{BlasInt}(undef, sw.liwork)
+    sw
+end
+
+mutable struct StegrCache{T,R<:Real} <: HermitianSubspaceCache{T}
+    v::Vector{T} # Subspace-propagated vector
+    w::Vector{T}
+    sw::StegrWork{R}
+    StegrCache(::Type{T}, n::Integer) where T = new{T,real(T)}(Vector{T}(undef, n), Vector{T}(undef, n), StegrWork(real(T), n))
+end
+
+function expT!(α::AbstractVector{R}, β::AbstractVector{R}, t::Number, cache::StegrCache{T,R}) where {T,R<:Real}
+    stegr!(α, β, cache.sw)
+    sel = 1:length(α)
+    @inbounds for i = sel
+        cache.w[i] = exp(t*cache.sw.w[i])*cache.sw.Z[1,i]
+    end
+    mul!(@view(cache.v[sel]), @view(cache.sw.Z[sel,sel]), @view(cache.w[sel]))
+end
+
+export StegrCache

--- a/src/stegr_cache.jl
+++ b/src/stegr_cache.jl
@@ -46,15 +46,27 @@ for (stegr,elty) in ((:dstegr_,:Float64),
     end
 end
 
+"""
+    stegr!(α, β, sw)
+
+Diagonalize the real-symmetric tridiagonal matrix with `α` on the
+diagonal and `β` on the super-/subdiagonal, using the workspaces
+allocated in `sw`.
+"""
 function stegr!(α::AbstractVector{T}, β::AbstractVector{T}, sw::StegrWork{T}) where T
     # @assert length(sw.dv) >= length(α)
     # @assert length(sw.ev) >= length(β)
     copyto!(sw.dv, α)
     copyto!(sw.ev, β)
-    n = BlasInt(length(α))
-    stegr!(n, sw)
+    stegr!(BlasInt(length(α)), sw)
 end
 
+"""
+    StegrWork(T, n)
+
+Allocate work arrays for diagonalization of real-symmetric tridiagonal
+matrices of sizes up to `n`×`n`.
+"""
 function StegrWork(::Type{T}, n::BlasInt,
                    jobz::Char = 'V', range::Char = 'A') where T
     dv = Array{T}(undef, n)
@@ -98,7 +110,15 @@ mutable struct StegrCache{T,R<:Real} <: HermitianSubspaceCache{T}
         StegrWork(real(T), BlasInt(n)))
 end
 
-function expT!(α::AbstractVector{R}, β::AbstractVector{R}, t::Number, cache::StegrCache{T,R}) where {T,R<:Real}
+"""
+    expT!(α, β, t, cache)
+
+Calculate the subspace exponential `exp(t*T)` for a tridiagonal
+subspace matrix `T` with `α` on the diagonal and `β` on the
+super-/subdiagonal, diagonalizing via `stegr!`.
+"""
+function expT!(α::AbstractVector{R}, β::AbstractVector{R}, t::Number,
+               cache::StegrCache{T,R}) where {T,R<:Real}
     stegr!(α, β, cache.sw)
     sel = 1:length(α)
     @inbounds for i = sel

--- a/src/stegr_cache.jl
+++ b/src/stegr_cache.jl
@@ -93,7 +93,9 @@ mutable struct StegrCache{T,R<:Real} <: HermitianSubspaceCache{T}
     v::Vector{T} # Subspace-propagated vector
     w::Vector{T}
     sw::StegrWork{R}
-    StegrCache(::Type{T}, n::Integer) where T = new{T,real(T)}(Vector{T}(undef, n), Vector{T}(undef, n), StegrWork(real(T), n))
+    StegrCache(::Type{T}, n::Integer) where T = new{T,real(T)}(
+        Vector{T}(undef, n), Vector{T}(undef, n),
+        StegrWork(real(T), BlasInt(n)))
 end
 
 function expT!(α::AbstractVector{R}, β::AbstractVector{R}, t::Number, cache::StegrCache{T,R}) where {T,R<:Real}

--- a/src/stegr_cache.jl
+++ b/src/stegr_cache.jl
@@ -110,6 +110,9 @@ mutable struct StegrCache{T,R<:Real} <: HermitianSubspaceCache{T}
         StegrWork(real(T), BlasInt(n)))
 end
 
+StegrCache(Ks::KrylovSubspace{B,T,U}) where {B,T,U} =
+    StegrCache(T, Ks.maxiter)
+
 """
     expT!(α, β, t, cache)
 
@@ -126,5 +129,3 @@ function expT!(α::AbstractVector{R}, β::AbstractVector{R}, t::Number,
     end
     mul!(@view(cache.v[sel]), @view(cache.sw.Z[sel,sel]), @view(cache.w[sel]))
 end
-
-export StegrCache

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,3 +105,35 @@ end
 
   @test norm(AH-LH)/norm(AH) < tol
 end
+
+@testset "Alternative Lanczos expv! interface" begin
+  n = 300
+  m = 30
+  A = Hermitian(rand(n,n))
+  Ks = KrylovSubspace{ComplexF64,Float64}(n,m)
+  sc = StegrCache(ComplexF64, n)
+
+  b = rand(ComplexF64, n)
+  w = similar(b)
+  w′ = similar(b)
+
+  dt = 0.1
+
+  atol=1e-10
+  rtol=1e-10
+  expv!(w, -im, dt*A, b, Ks, sc, atol=atol, rtol=rtol)
+
+  @test Ks.m < m
+
+  function fullexp!(w, A, v)
+      eA = exp(A)
+      mul!(w, eA, v)
+      w
+  end
+
+  fullexp!(w′, -im*dt*A, b)
+
+  δw = norm(w-w′)
+  @test δw < atol
+  @test δw/abs(1e-16+norm(w)) < rtol
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,32 +106,26 @@ end
   @test norm(AH-LH)/norm(AH) < tol
 end
 
-@testset "Alternative Lanczos expv! interface" begin
+@testset "Alternative Lanczos expv interface" begin
   n = 300
   m = 30
+
   A = Hermitian(rand(n,n))
-  Ks = KrylovSubspace{ComplexF64,Float64}(n,m)
-  sc = StegrCache(ComplexF64, n)
-
   b = rand(ComplexF64, n)
-  w = similar(b)
-  w′ = similar(b)
-
   dt = 0.1
 
   atol=1e-10
   rtol=1e-10
-  expv!(w, -im, dt*A, b, Ks, sc, atol=atol, rtol=rtol)
+  w = expv(-im, dt*A, b, m=m, tol=atol, rtol=rtol, mode=:error_estimate)
 
-  @test Ks.m < m
-
-  function fullexp!(w, A, v)
+  function fullexp(A, v)
+      w = similar(v)
       eA = exp(A)
       mul!(w, eA, v)
       w
   end
 
-  fullexp!(w′, -im*dt*A, b)
+  w′ = fullexp(-im*dt*A, b)
 
   δw = norm(w-w′)
   @test δw < atol


### PR DESCRIPTION
As discussed in #1, I've implemented an alternative interface to `exvp!` for the Hermitian case, where the Krylov subspace is successively built up, but the iteration is terminated, if a stopping criterion based on an exponentiation error estimate is fulfilled. For time-stepping, where the error of the exponentiation, and not the condition number of the Krylov subspace, is important, I have found this to be a more reliable indicator of when to terminate the iteration.

- This PR follows #5, but does not really depend on it, so before this is merged, it should be rebased on whatever state master is in at that time.
- The Krylov iterations previously used a separate `cache` vector, which I skipped. Instead I use the "next" vector in the subspace, i.e. `V[:,j+1]`, where `cache` after being orthogonalized and scaled would end up anyway. I have not, however, removed it from the call signature, since I still need to clean everywhere in `krylov_phiv_adaptive.jl`, which was not as fun to do.
- I've seen different broadcast mechanisms being used, but I am not sure about the subtler implications, i.e. which one is best where. Please check and tell me!
  - `@. V[:, 1] = 1 / beta`
  - `lmul!(1/beta, @view(V[:, 1])`
  - For loop:
    ```julia
     @inbounds for i = 1:size(V,1)
         V[i,1] = 1/beta
     end
     ```
- OK to keep `verbose` flag? I think it is nice to have when debugging time-stepping algorithms.
- As can be seen in the benchmarks below, there are still some allocations going on, which I'd like to get rid of, or at least minimize. Pointers would be great!
- It is not fantastically nice to have a LAPACK wrapper directly in the code, but I am not sure what else can be done at the moment, without a giant overhaul of `LinearAlgebra`.
- Something similar should be implemented for Arnoldi.
- Are there better unit tests that can be done?

As an example of usage and its performance, see the following code (which also doubles as the test):
```julia
n = 3000
m = 30
A = Hermitian(rand(n,n))
Ks = KrylovSubspace{ComplexF64,Float64}(n,m)
sc = StegrCache(ComplexF64, n)

b = rand(ComplexF64, n)
w = similar(b)
w′ = similar(b)

dt = 0.1

atol=1e-10
rtol=1e-10
expv!(w, -im, dt*A, b, Ks, sc, atol=atol, rtol=rtol, verbose=true)

println("Benchmarking Lanczos expv!")
@btime expv!(w, -im, dt*A, b, Ks, sc, atol=atol, rtol=rtol, verbose=false)

function fullexp!(w, A, v)
    eA = exp(A)
    mul!(w, eA, v)
    w
end
println("Benchmarking full exponentiation")
@btime fullexp!(w′, -im*dt*A, b)

norm(w-w′)
```

`n=300`
```
Initial norm: β₀ 1.380667e+01, stopping threshold: 1.480667e-09
iter 1, α[1] 1.087384e+01, β[1] 6.692534e+00, σ 9.240161e+01
iter 2, α[2] 4.099573e+00, β[2] 5.765774e-01, σ 6.664466e+00
iter 3, α[3] 1.026875e-02, β[3] 4.875859e-01, σ 1.600913e+00
iter 4, α[4] -3.137509e-04, β[4] 5.099652e-01, σ 4.215033e-01
iter 5, α[5] -2.819237e-02, β[5] 5.078813e-01, σ 7.169712e-02
iter 6, α[6] 1.549987e-03, β[6] 4.963334e-01, σ 8.827376e-03
iter 7, α[7] -2.843072e-03, β[7] 5.057275e-01, σ 8.815623e-04
iter 8, α[8] 3.516485e-02, β[8] 5.074857e-01, σ 7.329762e-05
iter 9, α[9] -1.400483e-02, β[9] 5.057665e-01, σ 5.180701e-06
iter 10, α[10] -1.756147e-02, β[10] 4.907045e-01, σ 3.096524e-07
iter 11, α[11] 2.551781e-02, β[11] 4.859925e-01, σ 1.624763e-08
iter 12, α[12] 1.383772e-02, β[12] 6.395702e-01, σ 1.007198e-09
Krylov subspace size: 12
Benchmarking Lanczos expv!
  1.089 ms (1359 allocations: 765.83 KiB)
Benchmarking full exponentiation
  29.685 ms (1320 allocations: 44.01 MiB)
7.58943925351473e-11
```

`n=3000`
```
Initial norm: β₀ 4.522136e+01, stopping threshold: 4.622136e-09
iter 1, α[1] 1.138220e+02, β[1] 6.424715e+01, σ 2.905344e+03
iter 2, α[2] 3.624997e+01, β[2] 1.814199e+00, σ 2.416432e+01
iter 3, α[3] -1.562011e-02, β[3] 1.595978e+00, σ 3.571388e+01
iter 4, α[4] -4.007526e-03, β[4] 1.594921e+00, σ 2.880494e+01
iter 5, α[5] 7.710502e-03, β[5] 1.589851e+00, σ 1.602004e+01
iter 6, α[6] 1.563939e-02, β[6] 1.567023e+00, σ 6.572510e+00
iter 7, α[7] 6.127848e-03, β[7] 1.601089e+00, σ 2.190977e+00
iter 8, α[8] 1.206389e-02, β[8] 1.598282e+00, σ 6.015621e-01
iter 9, α[9] 7.070683e-02, β[9] 1.622612e+00, σ 1.430245e-01
iter 10, α[10] 1.103534e+01, β[10] 3.919011e+01, σ 4.440673e-01
iter 11, α[11] 1.388096e+02, β[11] 5.896185e+00, σ 2.817613e-02
iter 12, α[12] 2.579454e-01, β[12] 1.598403e+00, σ 5.083859e-03
iter 13, α[13] -1.817458e-02, β[13] 1.567401e+00, σ 8.086115e-04
iter 14, α[14] -2.814222e-02, β[14] 1.568095e+00, σ 1.167917e-04
iter 15, α[15] -1.184318e-02, β[15] 1.563882e+00, σ 1.539143e-05
iter 16, α[16] 2.292472e-02, β[16] 1.547416e+00, σ 1.849834e-06
iter 17, α[17] -2.205499e-02, β[17] 1.583346e+00, σ 2.109877e-07
iter 18, α[18] 1.480475e-02, β[18] 1.672977e+00, σ 2.369455e-08
iter 19, α[19] 1.511450e+01, β[19] 4.513727e+01, σ 5.071813e-08
iter 20, α[20] 1.348318e+02, β[20] 4.894348e+00, σ 2.187540e-09
Krylov subspace size: 20
Benchmarking Lanczos expv!
  173.878 ms (12255 allocations: 69.22 MiB)
Benchmarking full exponentiation
  25.138 s (12128 allocations: 4.69 GiB)
1.293094021783796e-10
```