### PR TITLE
Minor things

### DIFF
--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -92,11 +92,11 @@ function arnoldi(A, b; m=min(30, size(A, 1)), tol=1e-7, opnorm=LinearAlgebra.opn
 end
 
 """
-    arnoldi_step!(j, A, V, H)
+    arnoldi_step!(j, iop, n, A, V, H)
 
 Take the `j`:th step of the Lanczos iteration.
 """
-function arnoldi_step!(j::Integer, iop::Integer, n::Integer, A,
+function arnoldi_step!(j::Integer, iop::Integer, A,
                        V::AbstractMatrix{T}, H::AbstractMatrix{U}) where {T,U}
     x,y = @view(V[:, j]),@view(V[:, j+1])
     mul!(y, A, x)
@@ -139,7 +139,7 @@ function arnoldi!(Ks::KrylovSubspace{B, T, U}, A, b::AbstractVector{T};
     Ks.beta = norm(b)
     @. V[:, 1] = b / Ks.beta
     @inbounds for j = 1:m
-        beta = arnoldi_step!(j, iop, n, A, V, H)
+        beta = arnoldi_step!(j, iop, A, V, H)
         if beta < vtol # happy-breakdown
             Ks.m = j
             break
@@ -149,11 +149,11 @@ function arnoldi!(Ks::KrylovSubspace{B, T, U}, A, b::AbstractVector{T};
 end
 
 """
-    lanczos_step!(j, A, V, H)
+    lanczos_step!(j, m, n, A, V, H)
 
 Take the `j`:th step of the Lanczos iteration.
 """
-function lanczos_step!(j::Integer, m::Integer, n::Integer, A,
+function lanczos_step!(j::Integer, A,
                        V::AbstractMatrix{T},
                        α::AbstractVector{U},
                        β::AbstractVector{B}) where {B,T,U}
@@ -216,7 +216,7 @@ function lanczos!(Ks::KrylovSubspace{B, T, U}, A, b::AbstractVector{T};
     # β is always real, even though α may (in general) be complex.
     β = realview(B, @diagview(H,-1))
     @inbounds for j = 1:m
-        if vtol > lanczos_step!(j, m, n, A, V, α, β)
+        if vtol > lanczos_step!(j, A, V, α, β)
             # happy-breakdown
             Ks.m = j
             break

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -86,7 +86,7 @@ advection-diffusion operator using the incomplete orthogonalization method. In
 Numerical Mathematics and Advanced Applications-ENUMATH 2013 (pp. 345-353).
 Springer, Cham.
 """
-function arnoldi(A, b; m=min(30, size(A, 1)), tol=1e-7, opnorm=LinearAlgebra.opnorm, iop=0)
+function arnoldi(A, b; m=min(30, size(A, 1)), tol=1e-7, opnorm=LinearAlgebra.opnorm, iop=0, cache=nothing )
     Ks = KrylovSubspace{eltype(b)}(length(b), m)
     arnoldi!(Ks, A, b; m=m, tol=tol, opnorm=opnorm, iop=iop)
 end
@@ -117,7 +117,7 @@ Non-allocating version of `arnoldi`.
 """
 function arnoldi!(Ks::KrylovSubspace{B, T, U}, A, b::AbstractVector{T};
                   tol::Real=1e-7, m::Int=min(Ks.maxiter, size(A, 1)),
-                  opnorm=LinearAlgebra.opnorm, iop::Int=0) where {B, T <: Number, U <: Number}
+                  opnorm=LinearAlgebra.opnorm, iop::Int=0, cache=nothing) where {B, T <: Number, U <: Number}
     if ishermitian(A)
         return lanczos!(Ks, A, b; tol=tol, m=m, opnorm=opnorm)
     end
@@ -197,7 +197,7 @@ Hermitian matrices.
 """
 function lanczos!(Ks::KrylovSubspace{B, T, U}, A, b::AbstractVector{T};
                   tol=1e-7, m=min(Ks.maxiter, size(A, 1)),
-                  opnorm=LinearAlgebra.opnorm) where {B, T <: Number, U <: Number}
+                  opnorm=LinearAlgebra.opnorm, cache=nothing) where {B, T <: Number, U <: Number}
     if m > Ks.maxiter
         resize!(Ks, m)
     else

--- a/src/krylov_expv.jl
+++ b/src/krylov_expv.jl
@@ -44,7 +44,7 @@ function expv!(w::AbstractVector{T}, t::Number, A, b::AbstractVector{T},
     n = size(V, 1)
 
     for j ∈ 1:m
-        lanczos_step!(j, m, n, A, V, α, β)
+        lanczos_step!(j, A, V, α, β)
         expT!(@view(α[1:j]), @view(β[1:j]), t, cache)
 
         # This is practical error estimate Er₂ from

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,132 +2,132 @@ using Test, LinearAlgebra, Random, SparseArrays, ExponentialUtilities
 using ExponentialUtilities: getH, getV
 
 @testset "Phi" begin
-  # Scalar phi
-  K = 4
-  z = 0.1
-  P = fill(0., K+1); P[1] = exp(z)
-  for i = 1:K
-    P[i+1] = (P[i] - 1/factorial(i-1))/z
-  end
-  @test phi(z, K) ≈ P
+    # Scalar phi
+    K = 4
+    z = 0.1
+    P = fill(0., K+1); P[1] = exp(z)
+    for i = 1:K
+        P[i+1] = (P[i] - 1/factorial(i-1))/z
+    end
+    @test phi(z, K) ≈ P
 
-  # Matrix phi (dense)
-  A = [0.1 0.2; 0.3 0.4]
-  P = Vector{Matrix{Float64}}(undef, K+1); P[1] = exp(A)
-  for i = 1:K
-    P[i+1] = (P[i] - 1/factorial(i-1)*I) / A
-  end
-  @test phi(A, K) ≈ P
+    # Matrix phi (dense)
+    A = [0.1 0.2; 0.3 0.4]
+    P = Vector{Matrix{Float64}}(undef, K+1); P[1] = exp(A)
+    for i = 1:K
+        P[i+1] = (P[i] - 1/factorial(i-1)*I) / A
+    end
+    @test phi(A, K) ≈ P
 
-  # Matrix phi (Diagonal)
-  A = Diagonal([0.1, 0.2, 0.3, 0.4])
-  Afull = Matrix(A)
-  P = phi(A, K)
-  Pfull = phi(Afull, K)
-  for i = 1:K+1
-    @test Matrix(P[i]) ≈ Pfull[i]
-  end
+    # Matrix phi (Diagonal)
+    A = Diagonal([0.1, 0.2, 0.3, 0.4])
+    Afull = Matrix(A)
+    P = phi(A, K)
+    Pfull = phi(Afull, K)
+    for i = 1:K+1
+        @test Matrix(P[i]) ≈ Pfull[i]
+    end
 end
 
 @testset "Arnoldi & Krylov" begin
-  # Krylov
-  n = 20; m = 5; K = 4
-  Random.seed!(0)
-  A = randn(n, n)
-  t = 1e-2
-  b = randn(n)
-  @test exp(t * A) * b ≈ expv(t, A, b; m=m)
-  P = phi(t * A, K)
-  W = fill(0., n, K+1)
-  for i = 1:K+1
-    W[:,i] = P[i] * b
-  end
-  Ks = arnoldi(A, b; m=m)
-  W_approx = phiv(t, Ks, K)
-  @test W ≈ W_approx
+    # Krylov
+    n = 20; m = 5; K = 4
+    Random.seed!(0)
+    A = randn(n, n)
+    t = 1e-2
+    b = randn(n)
+    @test exp(t * A) * b ≈ expv(t, A, b; m=m)
+    P = phi(t * A, K)
+    W = fill(0., n, K+1)
+    for i = 1:K+1
+        W[:,i] = P[i] * b
+    end
+    Ks = arnoldi(A, b; m=m)
+    W_approx = phiv(t, Ks, K)
+    @test W ≈ W_approx
 
-  # Happy-breakdown in Krylov
-  v = normalize(randn(n))
-  A = v * v' # A is Idempotent
-  Ks = arnoldi(A, b)
-  @test Ks.m == 2
+    # Happy-breakdown in Krylov
+    v = normalize(randn(n))
+    A = v * v' # A is Idempotent
+    Ks = arnoldi(A, b)
+    @test Ks.m == 2
 
-  # Arnoldi vs Lanczos
-  A = Hermitian(randn(n, n))
-  Aperm = A + 1e-10 * randn(n, n) # no longer Hermitian
-  w = expv(t, A, b; m=m)
-  wperm = expv(t, Aperm, b; m=m)
-  @test w ≈ wperm
+    # Arnoldi vs Lanczos
+    A = Hermitian(randn(n, n))
+    Aperm = A + 1e-10 * randn(n, n) # no longer Hermitian
+    w = expv(t, A, b; m=m)
+    wperm = expv(t, Aperm, b; m=m)
+    @test w ≈ wperm
 end
 
 @testset "Adaptive Krylov" begin
-  # Internal time-stepping for Krylov (with adaptation)
-  n = 100
-  K = 4
-  t = 5.0
-  tol = 1e-7
-  A = spdiagm(-1=>ones(n-1), 0=>-2*ones(n), 1=>ones(n-1))
-  B = randn(n, K+1)
-  Phi_half = phi(t/2 * A, K)
-  Phi = phi(t * A, K)
-  uhalf_exact = sum((t/2)^i * Phi_half[i+1] * B[:,i+1] for i = 0:K)
-  u_exact = sum(t^i * Phi[i+1] * B[:,i+1] for i = 0:K)
-  U = phiv_timestep([t/2, t], A, B; adaptive=true, tol=tol)
-  @test norm(U[:,1] - uhalf_exact) / norm(uhalf_exact) < tol
-  @test norm(U[:,2] - u_exact) / norm(u_exact) < tol
-  # p = 0 special case (expv_timestep)
-  u_exact = Phi[1] * B[:, 1]
-  u = expv_timestep(t, A, B[:, 1]; adaptive=true, tol=tol)
-  @test norm(u - u_exact) / norm(u_exact) < tol
+    # Internal time-stepping for Krylov (with adaptation)
+    n = 100
+    K = 4
+    t = 5.0
+    tol = 1e-7
+    A = spdiagm(-1=>ones(n-1), 0=>-2*ones(n), 1=>ones(n-1))
+    B = randn(n, K+1)
+    Phi_half = phi(t/2 * A, K)
+    Phi = phi(t * A, K)
+    uhalf_exact = sum((t/2)^i * Phi_half[i+1] * B[:,i+1] for i = 0:K)
+    u_exact = sum(t^i * Phi[i+1] * B[:,i+1] for i = 0:K)
+    U = phiv_timestep([t/2, t], A, B; adaptive=true, tol=tol)
+    @test norm(U[:,1] - uhalf_exact) / norm(uhalf_exact) < tol
+    @test norm(U[:,2] - u_exact) / norm(u_exact) < tol
+    # p = 0 special case (expv_timestep)
+    u_exact = Phi[1] * B[:, 1]
+    u = expv_timestep(t, A, B[:, 1]; adaptive=true, tol=tol)
+    @test norm(u - u_exact) / norm(u_exact) < tol
 end
 
 @testset "Krylov for Hermitian matrices" begin
-  # Hermitian matrices have real spectra. Ensure that the subspace
-  # matrix is representable as a real matrix.
+    # Hermitian matrices have real spectra. Ensure that the subspace
+    # matrix is representable as a real matrix.
 
-  n = 100
-  m = 15
-  tol = 1e-14
+    n = 100
+    m = 15
+    tol = 1e-14
 
-  e = ones(n)
-  p = -im*Tridiagonal(-e[2:end], 0e, e[2:end])
+    e = ones(n)
+    p = -im*Tridiagonal(-e[2:end], 0e, e[2:end])
 
-  KsA = KrylovSubspace{ComplexF64}(n, m)
-  KsL = KrylovSubspace{ComplexF64, Float64}(n, m)
+    KsA = KrylovSubspace{ComplexF64}(n, m)
+    KsL = KrylovSubspace{ComplexF64, Float64}(n, m)
 
-  v = rand(ComplexF64, n)
+    v = rand(ComplexF64, n)
 
-  arnoldi!(KsA, p, v)
-  lanczos!(KsL, p, v)
+    arnoldi!(KsA, p, v)
+    lanczos!(KsL, p, v)
 
-  AH = view(KsA.H,1:KsA.m,1:KsA.m)
-  LH = view(KsL.H,1:KsL.m,1:KsL.m)
+    AH = view(KsA.H,1:KsA.m,1:KsA.m)
+    LH = view(KsL.H,1:KsL.m,1:KsL.m)
 
-  @test norm(AH-LH)/norm(AH) < tol
+    @test norm(AH-LH)/norm(AH) < tol
 end
 
 @testset "Alternative Lanczos expv interface" begin
-  n = 300
-  m = 30
+    n = 300
+    m = 30
 
-  A = Hermitian(rand(n,n))
-  b = rand(ComplexF64, n)
-  dt = 0.1
+    A = Hermitian(rand(n,n))
+    b = rand(ComplexF64, n)
+    dt = 0.1
 
-  atol=1e-10
-  rtol=1e-10
-  w = expv(-im, dt*A, b, m=m, tol=atol, rtol=rtol, mode=:error_estimate)
+    atol=1e-10
+    rtol=1e-10
+    w = expv(-im, dt*A, b, m=m, tol=atol, rtol=rtol, mode=:error_estimate)
 
-  function fullexp(A, v)
-      w = similar(v)
-      eA = exp(A)
-      mul!(w, eA, v)
-      w
-  end
+    function fullexp(A, v)
+        w = similar(v)
+        eA = exp(A)
+        mul!(w, eA, v)
+        w
+    end
 
-  w′ = fullexp(-im*dt*A, b)
+    w′ = fullexp(-im*dt*A, b)
 
-  δw = norm(w-w′)
-  @test δw < atol
-  @test δw/abs(1e-16+norm(w)) < rtol
+    δw = norm(w-w′)
+    @test δw < atol
+    @test δw/abs(1e-16+norm(w)) < rtol
 end


### PR DESCRIPTION
- Added back `cache` kwarg for now, as requested in JuliaDiffEq/OrdinaryDiffEq.jl#517.
- Remove a few unused arguments to the `*_step!` methods
- Fixed indentation of tests