### PR TITLE
Use eltype of `b` rather than `A` in adaptive methods

### DIFF
--- a/src/krylov_phiv_adaptive.jl
+++ b/src/krylov_phiv_adaptive.jl
@@ -31,11 +31,11 @@ evaluating the φ-functions in exponential integrators. arXiv preprint
 arXiv:0907.4631.
 """
 function expv_timestep(ts::Vector{tType}, A, b; kwargs...) where {tType <: Real}
-    U = Matrix{eltype(A)}(undef, size(A, 1), length(ts))
+    U = Matrix{eltype(b)}(undef, size(A, 1), length(ts))
     expv_timestep!(U, ts, A, b; kwargs...)
 end
 function expv_timestep(t::tType, A, b; kwargs...) where {tType <: Real}
-    u = Vector{eltype(A)}(undef, size(A, 1))
+    u = Vector{eltype(b)}(undef, size(A, 1))
     expv_timestep!(u, t, A, b; kwargs...)
 end
 """
@@ -82,11 +82,11 @@ evaluating the φ-functions in exponential integrators. arXiv preprint
 arXiv:0907.4631.
 """
 function phiv_timestep(ts::Vector{tType}, A, B; kwargs...) where {tType <: Real}
-    U = Matrix{eltype(A)}(undef, size(A, 1), length(ts))
+    U = Matrix{eltype(b)}(undef, size(A, 1), length(ts))
     phiv_timestep!(U, ts, A, B; kwargs...)
 end
 function phiv_timestep(t::tType, A, B; kwargs...) where {tType <: Real}
-    u = Vector{eltype(A)}(undef, size(A, 1))
+    u = Vector{eltype(b)}(undef, size(A, 1))
     phiv_timestep!(u, t, A, B; kwargs...)
 end
 """

--- a/src/krylov_phiv_adaptive.jl
+++ b/src/krylov_phiv_adaptive.jl
@@ -82,11 +82,11 @@ evaluating the φ-functions in exponential integrators. arXiv preprint
 arXiv:0907.4631.
 """
 function phiv_timestep(ts::Vector{tType}, A, B; kwargs...) where {tType <: Real}
-    U = Matrix{eltype(b)}(undef, size(A, 1), length(ts))
+    U = Matrix{eltype(B)}(undef, size(A, 1), length(ts))
     phiv_timestep!(U, ts, A, B; kwargs...)
 end
 function phiv_timestep(t::tType, A, B; kwargs...) where {tType <: Real}
-    u = Vector{eltype(b)}(undef, size(A, 1))
+    u = Vector{eltype(B)}(undef, size(A, 1))
     phiv_timestep!(u, t, A, B; kwargs...)
 end
 """


### PR DESCRIPTION
I have found that for time-adaptive methods like `phiv_timestep` in `ExponentialUtilities.jl`, `eltype(A)` for an operator `A` should be also defined. Isn't it sufficient to use `eltype(b)` in the code instead, as each element of the corresponding matrix `U` (lin comb of $t^p \varphi(tA)$) will have the element type of `b`?

Here's a MWE:
```julia
# TransitionModel defn
struct TransitionModel
    A
end

LinearAlgebra.size(m::TransitionModel, i::Int64) = size(m.A, i)
LinearAlgebra.ishermitian(m::TransitionModel) = ishermitian(m.A)
LinearAlgebra.mul!(y, m::TransitionModel, b) = mul!(y, m.A, b)
function LinearAlgebra.mul!(Y, m::TransitionModel, B::AbstractMatrix{T}) where {T} 
    N = size(A,1)
    for j in 1:(N+1)
        y = Y[:,j]
        mul!(y, m, B[:,j])
        Y[:,j] = y
    end    
end
LinearAlgebra.opnorm(m::TransitionModel, p) = opnorm(m.A, p)

# model specs
A = [[-0.5 0.25 0.25]; [-0.5 0.0 0.5]; [0.0 -0.5 0.5]]
model = TransitionModel(A)

# solution setup
T = 1
ts = 0:0.1:T
f_0 = [1.0; 0.0; 0.0]

# solve
sols = ExponentialUtilities.expv_timestep(union(ts),model,f_0)
```
which returns the following error before if the change in code base isn't made:
```
MethodError: no method matching expv_timestep!(::Array{Any,2}, ::Array{Float64,1}, ::TransitionModel, ::Array{Float64,1})
Closest candidates are:
  expv_timestep!(!Matched::AbstractArray{T<:Number,2}, ::Array{tType<:Real,1}, ::Any, ::AbstractArray{T<:Number,1}; kwargs...) where {T<:Number, tType<:Real} at C:\Users\Chiyoung Ahn\.julia\packages\ExponentialUtilities\3nv8i\src\krylov_phiv_adaptive.jl:53
  expv_timestep!(!Matched::AbstractArray{T<:Number,1}, !Matched::tType<:Real, ::Any, ::AbstractArray{T<:Number,1}; kwargs...) where {T<:Number, tType<:Real} at C:\Users\Chiyoung Ahn\.julia\packages\ExponentialUtilities\3nv8i\src\krylov_phiv_adaptive.jl:48

Stacktrace:
 [1] #expv_timestep#22(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::Array{Float64,1}, ::TransitionModel, ::Array{Float64,1}) at C:\Users\Chiyoung Ahn\.julia\packages\ExponentialUtilities\3nv8i\src\krylov_phiv_adaptive.jl:35
 [2] expv_timestep(::Array{Float64,1}, ::TransitionModel, ::Array{Float64,1}) at C:\Users\Chiyoung Ahn\.julia\packages\ExponentialUtilities\3nv8i\src\krylov_phiv_adaptive.jl:34
 [3] top-level scope at In[2]:28
```