### PR TITLE
WIP: Non-allocating `exp!`

### DIFF
--- a/src/ExponentialUtilities.jl
+++ b/src/ExponentialUtilities.jl
@@ -1,7 +1,7 @@
 module ExponentialUtilities
 using LinearAlgebra, SparseArrays, Printf
-using LinearAlgebra: exp!, BlasInt
-using LinearAlgebra.LAPACK: stegr!
+using LinearAlgebra: exp!, BlasInt, BlasFloat, checksquare
+using LinearAlgebra.LAPACK: stegr!, gebal!, gesv!
 
 """
     @diagview(A,d) -> view of the `d`th diagonal of `A`.
@@ -14,6 +14,7 @@ macro diagview(A,d::Integer=0)
     end
 end
 
+include("exp.jl")
 include("phi.jl")
 include("arnoldi.jl")
 include("krylov_phiv.jl")

--- a/src/ExponentialUtilities.jl
+++ b/src/ExponentialUtilities.jl
@@ -1,6 +1,6 @@
 module ExponentialUtilities
 using LinearAlgebra, SparseArrays, Printf
-using LinearAlgebra: exp!, BlasInt, BlasFloat, checksquare
+using LinearAlgebra: BlasInt, BlasFloat, checksquare
 using LinearAlgebra.LAPACK: stegr!, gebal!, gesv!
 
 """

--- a/src/ExponentialUtilities.jl
+++ b/src/ExponentialUtilities.jl
@@ -1,7 +1,5 @@
 module ExponentialUtilities
 using LinearAlgebra, SparseArrays, Printf
-using LinearAlgebra: BlasInt, BlasFloat, checksquare
-using LinearAlgebra.LAPACK: stegr!, gebal!, gesv!
 
 """
     @diagview(A,d) -> view of the `d`th diagonal of `A`.

--- a/src/StegrWork.jl
+++ b/src/StegrWork.jl
@@ -69,8 +69,9 @@ end
 Allocate work arrays for diagonalization of real-symmetric tridiagonal
 matrices of sizes up to `n`×`n`.
 """
-function StegrWork(::Type{T}, n::BlasInt,
+function StegrWork(::Type{T}, n::Integer,
                    jobz::Char = 'V', range::Char = 'A') where T
+    n = convert(BlasInt, n)
     dv = Array{T}(undef, n)
     ev = Array{T}(undef, n)
     abstol = Array{T}(undef, 1)

--- a/src/exp.jl
+++ b/src/exp.jl
@@ -3,8 +3,8 @@
 ##
 ## Non-allocating version of `LinearAlgebra.exp!`. Modifies `X` to
 ## become (approximately) `exp(A)`. `X` and `A` may alias.
-function _exp!(X::StridedMatrix{T}, A::StridedMatrix{T}; caches=nothing) where T<:BlasFloat
-    n = checksquare(A)
+function _exp!(X::StridedMatrix{T}, A::StridedMatrix{T}; caches=nothing) where T <: LinearAlgebra.BlasFloat
+    n = LinearAlgebra.checksquare(A)
     # if ishermitian(A)
         # return copytri!(parent(exp(Hermitian(A))), 'U', true)
     # end
@@ -20,7 +20,7 @@ function _exp!(X::StridedMatrix{T}, A::StridedMatrix{T}; caches=nothing) where T
     end
     fill!(P, zero(T)); fill!(@diagview(P), one(T)) # P = Inn
 
-    ilo, ihi, scale = gebal!('B', A)    # modifies A
+    ilo, ihi, scale = LAPACK.gebal!('B', A)    # modifies A
     nA = opnorm(A, 1)
     ## For sufficiently small nA, use lower order Padé-Approximations
     if (nA <= 2.1)
@@ -49,7 +49,7 @@ function _exp!(X::StridedMatrix{T}, A::StridedMatrix{T}; caches=nothing) where T
         mul!(temp, A, U); U, temp = temp, U # equivalent to U = A * U
         @. X = V + U
         @. temp = V - U
-        gesv!(temp, X)
+        LAPACK.gesv!(temp, X)
     else
         s  = log2(nA/5.4)               # power of 2 later reversed by squaring
         if s > 0
@@ -73,7 +73,7 @@ function _exp!(X::StridedMatrix{T}, A::StridedMatrix{T}; caches=nothing) where T
         mul!(temp, A, U); U, temp = temp, U # equivalent to U = A * U
         @. X = V + U
         @. temp = V - U
-        gesv!(temp, X)
+        LAPACK.gesv!(temp, X)
 
         if s > 0            # squaring to reverse dividing by power of 2
             for t=1:si

--- a/src/exp.jl
+++ b/src/exp.jl
@@ -2,7 +2,7 @@
 ## "Functions of Matrices: Theory and Computation", SIAM
 ##
 ## Non-allocating version of `LinearAlgebra.exp!`. Modifies `X` to
-## become (approximately) `exp(A)`.
+## become (approximately) `exp(A)`. `X` and `A` may alias.
 function _exp!(X::StridedMatrix{T}, A::StridedMatrix{T}; caches=nothing) where T<:BlasFloat
     n = checksquare(A)
     # if ishermitian(A)
@@ -95,11 +95,10 @@ function _exp!(X::StridedMatrix{T}, A::StridedMatrix{T}; caches=nothing) where T
     end
 
     if ilo > 1       # apply lower permutations in reverse order
-        for j in (ilo-1):-1:1; rcswap!(j, Int(scale[j]), X) end
+        for j in (ilo-1):-1:1; LinearAlgebra.rcswap!(j, Int(scale[j]), X) end
     end
     if ihi < n       # apply upper permutations in forward order
-        for j in (ihi+1):n;    rcswap!(j, Int(scale[j]), X) end
+        for j in (ihi+1):n;    LinearAlgebra.rcswap!(j, Int(scale[j]), X) end
     end
-    X
+    return X
 end
-

--- a/src/exp.jl
+++ b/src/exp.jl
@@ -1,0 +1,105 @@
+## Destructive matrix exponential using algorithm from Higham, 2008,
+## "Functions of Matrices: Theory and Computation", SIAM
+##
+## Non-allocating version of `LinearAlgebra.exp!`. Modifies `X` to
+## become (approximately) `exp(A)`.
+function _exp!(X::StridedMatrix{T}, A::StridedMatrix{T}; caches=nothing) where T<:BlasFloat
+    n = checksquare(A)
+    # if ishermitian(A)
+        # return copytri!(parent(exp(Hermitian(A))), 'U', true)
+    # end
+
+    if caches == nothing
+        A2   = Matrix{T}(undef, n, n)
+        P    = Matrix{T}(undef, n, n)
+        U    = Matrix{T}(undef, n, n)
+        V    = Matrix{T}(undef, n, n)
+        temp = Matrix{T}(undef, n, n)
+    else
+        A2, P, U, V, temp = caches
+    end
+    fill!(P, zero(T)); fill!(@diagview(P), one(T)) # P = Inn
+
+    ilo, ihi, scale = gebal!('B', A)    # modifies A
+    nA = opnorm(A, 1)
+    ## For sufficiently small nA, use lower order Padé-Approximations
+    if (nA <= 2.1)
+        if nA > 0.95
+            C = T[17643225600.,8821612800.,2075673600.,302702400.,
+                     30270240.,   2162160.,    110880.,     3960.,
+                           90.,         1.]
+        elseif nA > 0.25
+            C = T[17297280.,8648640.,1995840.,277200.,
+                     25200.,   1512.,     56.,     1.]
+        elseif nA > 0.015
+            C = T[30240.,15120.,3360.,
+                    420.,   30.,   1.]
+        else
+            C = T[120.,60.,12.,1.]
+        end
+        mul!(A2, A, A)
+        @. U = C[2] * P
+        @. V = C[1] * P
+        for k in 1:(div(size(C, 1), 2) - 1)
+            k2 = 2 * k
+            mul!(temp, P, A2); P, temp = temp, P # equivalent to P *= A2
+            @. U += C[k2 + 2] * P
+            @. V += C[k2 + 1] * P
+        end
+        mul!(temp, A, U); U, temp = temp, U # equivalent to U = A * U
+        @. X = V + U
+        @. temp = V - U
+        gesv!(temp, X)
+    else
+        s  = log2(nA/5.4)               # power of 2 later reversed by squaring
+        if s > 0
+            si = ceil(Int,s)
+            A ./= convert(T,2^si)
+        end
+        C  = T[64764752532480000.,32382376266240000.,7771770303897600.,
+                1187353796428800.,  129060195264000.,  10559470521600.,
+                    670442572800.,      33522128640.,      1323241920.,
+                        40840800.,           960960.,           16380.,
+                             182.,                1.]
+        mul!(A2, A, A)
+        @. U = C[2] * P
+        @. V = C[1] * P
+        for k in 1:6
+            k2 = 2 * k
+            mul!(temp, P, A2); P, temp = temp, P # equivalent to P *= A2
+            @. U += C[k2 + 2] * P
+            @. V += C[k2 + 1] * P
+        end
+        mul!(temp, A, U); U, temp = temp, U # equivalent to U = A * U
+        @. X = V + U
+        @. temp = V - U
+        gesv!(temp, X)
+
+        if s > 0            # squaring to reverse dividing by power of 2
+            for t=1:si
+                mul!(temp, X, X)
+                X .= temp
+            end
+        end
+    end
+
+    # Undo the balancing
+    for j = ilo:ihi
+        scj = scale[j]
+        for i = 1:n
+            X[j,i] *= scj
+        end
+        for i = 1:n
+            X[i,j] /= scj
+        end
+    end
+
+    if ilo > 1       # apply lower permutations in reverse order
+        for j in (ilo-1):-1:1; rcswap!(j, Int(scale[j]), X) end
+    end
+    if ihi < n       # apply upper permutations in forward order
+        for j in (ihi+1):n;    rcswap!(j, Int(scale[j]), X) end
+    end
+    X
+end
+

--- a/src/exp.jl
+++ b/src/exp.jl
@@ -1,9 +1,10 @@
 ## Destructive matrix exponential using algorithm from Higham, 2008,
 ## "Functions of Matrices: Theory and Computation", SIAM
 ##
-## Non-allocating version of `LinearAlgebra.exp!`. Modifies `X` to
-## become (approximately) `exp(A)`. `X` and `A` may alias.
-function _exp!(X::StridedMatrix{T}, A::StridedMatrix{T}; caches=nothing) where T <: LinearAlgebra.BlasFloat
+## Non-allocating version of `LinearAlgebra.exp!`. Modifies `A` to
+## become (approximately) `exp(A)`.
+function _exp!(A::StridedMatrix{T}; caches=nothing) where T <: LinearAlgebra.BlasFloat
+    X = A
     n = LinearAlgebra.checksquare(A)
     # if ishermitian(A)
         # return copytri!(parent(exp(Hermitian(A))), 'U', true)

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -86,7 +86,7 @@ function expv!(w::AbstractVector{Tw}, t::Real, Ks::KrylovSubspace{B, T, U};
         expHe = F.vectors * (exp.(lmul!(t,F.values)) .* @view(F.vectors[1, :]))
     else
         lmul!(t, cache); expH = cache
-        _exp!(expH, cache)
+        _exp!(expH)
         expHe = @view(expH[:, 1])
     end
     lmul!(beta, mul!(w, @view(V[:, 1:m]), expHe)) # exp(A) ≈ norm(b) * V * exp(H)e
@@ -112,8 +112,7 @@ function expv!(w::AbstractVector{Complex{Tw}}, t::Complex{Tt}, Ks::KrylovSubspac
         F = eigen!(SymTridiagonal(cache))
         expHe = F.vectors * (exp.(t * F.values) .* @view(F.vectors[1, :]))
     else
-        expH = t_cache = t * cache
-        _exp!(expH, t_cache)
+        expH = _exp!(t * cache)
         expHe = @view(expH[:, 1])
     end
     lmul!(beta, mul!(w, @view(V[:, 1:m]), expHe)) # exp(A) ≈ norm(b) * V * exp(H)e

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -85,7 +85,8 @@ function expv!(w::AbstractVector{Tw}, t::Real, Ks::KrylovSubspace{B, T, U};
         F = eigen!(SymTridiagonal(cache))
         expHe = F.vectors * (exp.(lmul!(t,F.values)) .* @view(F.vectors[1, :]))
     else
-        expH = exp!(lmul!(t,cache))
+        lmul!(t, cache); expH = cache
+        _exp!(expH, cache)
         expHe = @view(expH[:, 1])
     end
     lmul!(beta, mul!(w, @view(V[:, 1:m]), expHe)) # exp(A) ≈ norm(b) * V * exp(H)e
@@ -111,7 +112,8 @@ function expv!(w::AbstractVector{Complex{Tw}}, t::Complex{Tt}, Ks::KrylovSubspac
         F = eigen!(SymTridiagonal(cache))
         expHe = F.vectors * (exp.(t * F.values) .* @view(F.vectors[1, :]))
     else
-        expH = exp!(t * cache)
+        expH = t_cache = t * cache
+        _exp!(expH, t_cache)
         expHe = @view(expH[:, 1])
     end
     lmul!(beta, mul!(w, @view(V[:, 1:m]), expHe)) # exp(A) ≈ norm(b) * V * exp(H)e

--- a/src/krylov_phiv_error_estimate.jl
+++ b/src/krylov_phiv_error_estimate.jl
@@ -13,7 +13,7 @@ mutable struct StegrCache{T,R<:Real} <: HermitianSubspaceCache{T}
     sw::Stegr.StegrWork{R}
     StegrCache(::Type{T}, n::Integer) where T = new{T,real(T)}(
         Vector{T}(undef, n), Vector{T}(undef, n),
-        Stegr.StegrWork(real(T), BlasInt(n)))
+        Stegr.StegrWork(real(T), n))
 end
 
 """
@@ -25,7 +25,7 @@ super-/subdiagonal, diagonalizing via `stegr!`.
 """
 function expT!(α::AbstractVector{R}, β::AbstractVector{R}, t::Number,
                cache::StegrCache{T,R}) where {T,R<:Real}
-    stegr!(α, β, cache.sw)
+    LAPACK.stegr!(α, β, cache.sw)
     sel = 1:length(α)
     @inbounds for i = sel
         cache.w[i] = exp(t*cache.sw.w[i])*cache.sw.Z[1,i]

--- a/src/phi.jl
+++ b/src/phi.jl
@@ -28,7 +28,8 @@ function phi(z::T, k::Integer; cache=nothing) where {T <: Number}
     for i = 1:k
         cache[i,i+1] = one(T)
     end
-    P = exp!(cache)
+    P = cache
+    _exp!(P, cache)
     return P[1,:]
 end
 
@@ -74,7 +75,8 @@ function phiv_dense!(w::AbstractMatrix{T}, A::AbstractMatrix{T},
     for i = m+1:m+k-1
         cache[i, i+1] = one(T)
     end
-    P = exp!(cache)
+    P = cache
+    _exp!(P, cache)
     # Extract results
     @views mul!(w[:, 1], P[1:m, 1:m], v)
     @inbounds for i = 1:k

--- a/src/phi.jl
+++ b/src/phi.jl
@@ -28,8 +28,7 @@ function phi(z::T, k::Integer; cache=nothing) where {T <: Number}
     for i = 1:k
         cache[i,i+1] = one(T)
     end
-    P = cache
-    _exp!(P, cache)
+    P = _exp!(cache)
     return P[1,:]
 end
 
@@ -75,8 +74,7 @@ function phiv_dense!(w::AbstractMatrix{T}, A::AbstractMatrix{T},
     for i = m+1:m+k-1
         cache[i, i+1] = one(T)
     end
-    P = cache
-    _exp!(P, cache)
+    P = _exp!(cache)
     # Extract results
     @views mul!(w[:, 1], P[1:m, 1:m], v)
     @inbounds for i = 1:k

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,14 @@
 using Test, LinearAlgebra, Random, SparseArrays, ExponentialUtilities
-using ExponentialUtilities: getH, getV
+using ExponentialUtilities: getH, getV, _exp!
+
+@testset "Exp" begin
+    n = 100
+    A = randn(n, n)
+    expA = exp(A)
+    X = zeros(n, n)
+    _exp!(X, A)
+    @test X ≈ expA
+end
 
 @testset "Phi" begin
     # Scalar phi

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,13 @@ using ExponentialUtilities: getH, getV, _exp!
     n = 100
     A = randn(n, n)
     expA = exp(A)
-    X = zeros(n, n)
-    _exp!(X, A)
-    @test X ≈ expA
+    _exp!(A)
+    @test A ≈ expA
+    A2 = randn(n, n)
+    A2 ./= opnorm(A2, 1) # test for small opnorm
+    expA2 = exp(A2)
+    _exp!(A2)
+    @test A2 ≈ expA2
 end
 
 @testset "Phi" begin


### PR DESCRIPTION
I have translated the `exp!` function in `LinearAlgebra` to a non-allocating version (temporarily named `_exp!`). The next step is to replace the `exp!` occurrences in the package to `_exp!` and then remove the former.

In cases where the matrices for which `exp!` is called are small (i.e. small number of Krylov iterations) I suspect there won't be too much improvement (though adding them up can still probably save some noticeable time). The improvement should be more visible for larger Krylov subspaces.